### PR TITLE
Extended templates create props fix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,5 @@
+## 2.1.2
+* Added feature to allow `toClient` and `toServer` properties on an extended template.
 ## 2.1.1
 * Fix to support IE with lazy template loading
 ## 2.1.0

--- a/index.js
+++ b/index.js
@@ -211,8 +211,19 @@ ObjectTemplate.create = function create(name, properties) {
  * @returns {*} the object template
  */
 ObjectTemplate.extend = function extend(parentTemplate, name, properties) {
+    var props;
+    var createProps;
+
     if (!parentTemplate.__objectTemplate__) {
         throw new Error('incorrect parent template');
+    }
+
+    if (typeof(name) != 'undefined' && name.name) {
+        props = name;
+        name = props.name;
+    }
+    else {
+        props = parentTemplate.__createProps__;
     }
 
     if (typeof(name) != 'string' || name.match(/[^A-Za-z0-9_]/)) {
@@ -239,6 +250,10 @@ ObjectTemplate.extend = function extend(parentTemplate, name, properties) {
         }
     }
 
+    if (props) {
+        createProps = this.getTemplateProperties(props);
+    }
+
     if (typeof(this.templateInterceptor) == 'function') {
         this.templateInterceptor('extend', name, properties);
     }
@@ -252,7 +267,12 @@ ObjectTemplate.extend = function extend(parentTemplate, name, properties) {
         template = this._createTemplate(null, parentTemplate, name, parentTemplate, name);
     }
 
-    this.setTemplateProperties(template, name, parentTemplate);
+    if (createProps) {
+        this.setTemplateProperties(template, name, createProps);
+    } else {
+        this.setTemplateProperties(template, name, parentTemplate);
+    }
+    template.__createProps__ = props;
 
     // Maintain graph of parent and child templates
     template.__parent__ = parentTemplate;

--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ ObjectTemplate.setTemplateProperties = function setTemplateProperties(template, 
  * @returns {*} the object template
  */
 ObjectTemplate.create = function create(name, properties) {
-    if (typeof(name) != 'undefined' && name.name) {
+    if (name && name.name) {
         var props = name;
         name = props.name;
     }
@@ -205,7 +205,11 @@ ObjectTemplate.create = function create(name, properties) {
  * Extend and existing (parent template)
  *
  * @param {unknown} parentTemplate unknown
- * @param {unknown} name of the template
+ * @param {unknown} name the name of the template or an object with
+ *        name - the name of the class
+ *        toClient - whether the object is to be shipped to the client (with semotus)
+ *        toServer - whether the object is to be shipped to the server (with semotus)
+ *        isLocal - equivalent to setting toClient && toServer to false
  * @param {unknown} properties are the same as for create
  *
  * @returns {*} the object template
@@ -218,7 +222,7 @@ ObjectTemplate.extend = function extend(parentTemplate, name, properties) {
         throw new Error('incorrect parent template');
     }
 
-    if (typeof(name) != 'undefined' && name.name) {
+    if (name && name.name) {
         props = name;
         name = props.name;
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     },
     "scripts": {
         "lint": "eslint .",
-        "test": "./node_modules/mocha/bin/mocha ./test/*.js"
+        "test": "./node_modules/mocha/bin/mocha ./test/*.js",
+        "test:coverage": "instanbul cover _mocha -- test/* -R spec"
     },
     "directories": {
     },

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     },
     "scripts": {
         "lint": "eslint .",
-        "test": "istanbul cover _mocha -- test/* -R spec",
-        "test:config": "mocha test/config",
-        "test:example": "mocha test/example"
+        "test": "./node_modules/mocha/bin/mocha ./test/*.js"
     },
     "directories": {
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "supertype",
     "description": "A type system for classical inheritence, mix-ins and composition.",
     "homepage": "https://github.com/selsamman/supertype",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "devDependencies": {
         "chai": "*",
         "eslint": "3.7.x",

--- a/test/extending.js
+++ b/test/extending.js
@@ -1,114 +1,153 @@
 var expect = require('chai').expect;
 var ObjectTemplate = require('../index.js');
 
+var BaseTemplate1 = ObjectTemplate.create('BaseTemplate1',
+    {
+        boolTrue:   {type: Boolean, value: true},
+        boolFalse:  {type: Boolean, value: false},
+        num:        {type: Number, value: 100},
+        str:        {type: String, value: 'Base'},
+        obj:        {type: Object, value: {type: 'Base'}},
+        date:       {type: Date, value: new Date(100)},
+        enum:		{type: String, values: ['b1'], descriptions: {'b1': 'BaseTemplate1'}}
+    }
+);
 
+var ExtendedTemplate1 = BaseTemplate1.extend('ExtendedTemplate1',
+    {
+        boolTrue:   {type: Boolean, value: false},
+        boolFalse:  {type: Boolean, value: true},
+        num:        {type: Number, value: 200},
+        str:        {type: String, value: 'Extended'},
+        obj:        {type: Object, value: {type: 'Extended'}},
+        date:       {type: Date, value: new Date(200)},
+        init: function () {
+            BaseTemplate1.call(this);
+        },
+    }
+);
 
-describe("Extended Templates", function () {
-	it ("has extended values", function () {
-		var BaseTemplate1 = ObjectTemplate.create("BaseTemplate1",
-			{
-				boolTrue:   {type: Boolean, value: true},
-				boolFalse:  {type: Boolean, value: false},
-				num:        {type: Number, value: 100},
-				str:        {type: String, value: 'Base'},
-				obj:        {type: Object, value: {type: 'Base'}},
-				date:       {type: Date, value: new Date(100)},
-				enum:		{type: String, values: ['b1'], descriptions: {'b1': 'BaseTemplate1'}}
-			});
+var BaseTemplate2 = ObjectTemplate.create('BaseTemplate2', {
+        boolTrue:   {type: Boolean, value: true},
+        boolFalse:  {type: Boolean, value: false},
+        num:        {type: Number, value: 100},
+        str:        {type: String, value: 'Base'},
+        obj:        {type: Object, value: {type: 'Base'}},
+        date:       {type: Date, value: new Date(100)},
+        enum:		{type: String, values: ['b1'], descriptions: {'b1': 'BaseTemplate1'}}
+    }
+);
 
-		var ExtendedTemplate1 = BaseTemplate1.extend("ExtendedTemplate1",
-			{
-				boolTrue:   {type: Boolean, value: false},
-				boolFalse:  {type: Boolean, value: true},
-				num:        {type: Number, value: 200},
-				str:        {type: String, value: 'Extended'},
-				obj:        {type: Object, value: {type: 'Extended'}},
-				date:       {type: Date, value: new Date(200)},
-				init: function () {
-					BaseTemplate1.call(this);
-				},
-			});
+var ExtendedTemplate2 = BaseTemplate1.extend('ExtendedTemplate2',
+    {
+        boolTrue:   {type: Boolean, value: false},
+        boolFalse:  {type: Boolean, value: true},
+        num:        {type: Number, value: 200},
+        str:        {type: String, value: 'Extended'},
+        obj:        {type: Object, value: {type: 'Extended'}},
+        date:       {type: Date, value: new Date(200)},
+        init: function () {
+            BaseTemplate1.call(this);
+            this.boolTrue = true;
+            this.boolFalse = false;
+            this.num = 100;
+            this.str = 'Base';
+            this.obj = {type: 'Base'};
+            this.date = new Date(100);
+        },
+    }
+);
 
-		var ExtendedTemplate2 = BaseTemplate1.extend("ExtendedTemplate2",
-			{
-				boolTrue:   {type: Boolean, value: false},
-				boolFalse:  {type: Boolean, value: true},
-				num:        {type: Number, value: 200},
-				str:        {type: String, value: 'Extended'},
-				obj:        {type: Object, value: {type: 'Extended'}},
-				date:       {type: Date, value: new Date(200)},
-				init: function () {
-					BaseTemplate1.call(this);
-					this.boolTrue = true;
-					this.boolFalse = false;
-					this.num = 100;
-					this.str = 'Base';
-					this.obj = {type: 'Base'};
-					this.date = new Date(100);
-				},
-			});
+var ExtendedTemplate3 = BaseTemplate1.extend('ExtendedTemplate1',
+    {
+        boolTrue:   {type: Boolean, value: false},
+        boolFalse:  {type: Boolean, value: true},
+        num:        {type: Number, value: 200},
+        str:        {type: String, value: 'Extended'},
+        obj:        {type: Object, value: {type: 'Extended'}},
+        date:       {type: Date, value: new Date(200)},
+        init: function () {
+            BaseTemplate1.call(this);
+            this.boolTrue = false;
+            this.boolFalse = true;
+            this.num = 200;
+            this.str = 'Extended';
+            this.obj = {type: 'Extended'};
+            this.date = new Date(200);
+        },
+    }
+);
 
-		var ExtendedTemplate3 = BaseTemplate1.extend("ExtendedTemplate1",
-			{
-				boolTrue:   {type: Boolean, value: false},
-				boolFalse:  {type: Boolean, value: true},
-				num:        {type: Number, value: 200},
-				str:        {type: String, value: 'Extended'},
-				obj:        {type: Object, value: {type: 'Extended'}},
-				date:       {type: Date, value: new Date(200)},
-				init: function () {
-					BaseTemplate1.call(this);
-					this.boolTrue = false;
-					this.boolFalse = true;
-					this.num = 200;
-					this.str = 'Extended';
-					this.obj = {type: 'Extended'};
-					this.date = new Date(200);
-				},
-			});
+var ExtendedTemplate4 = ExtendedTemplate3.extend('ExtendedTemplate4',
+    {
+        enum: {
+            type: String,
+            values: function () {return ['b3']},
+            descriptions: function () {return {'b3': this.str}}
+        }
+    }
+);
 
-		var ExtendedTemplate4 = ExtendedTemplate3.extend("ExtendedTemplate4",
-			{
-				enum:		{type: String, 
-					values: function () {return ['b3']},
-					descriptions: function () {return {'b3': this.str}}}
-			});
-        var ExtendedTemplate5 = ExtendedTemplate3.extend("ExtendedTemplate4",
-            {
-                enum:		{type: String,
-                    values: function () {return ['b3']},
-                    descriptions: function () {return {'b3': this.str}}}
-            });
+var ExtendedTemplate5 = ExtendedTemplate3.extend('ExtendedTemplate4',
+    {
+        enum: {
+                type: String,
+                values: function () {return ['b3']},
+                descriptions: function () {return {'b3': this.str}}
+              }
+    }
+);
 
-    expect(ObjectTemplate.__templateUsage__['BaseTemplate1']).to.equal(undefined);
-		expect((new ExtendedTemplate1()).boolTrue).to.equal(false);
-    expect(ObjectTemplate.__templateUsage__['BaseTemplate1']).to.equal(true);
-    expect(ObjectTemplate.__templateUsage__['ExtendedTemplate1']).to.equal(true);
-    expect((new ExtendedTemplate1()).boolFalse).to.equal(true);
-		expect((new ExtendedTemplate1()).num).to.equal(200);
-		expect((new ExtendedTemplate1()).str).to.equal('Extended');
-		expect((new ExtendedTemplate1()).obj.type).to.equal('Extended');
-		expect((new ExtendedTemplate1()).date.getTime()).to.equal(200);
+describe('#extend', function() {
 
-		expect((new ExtendedTemplate2()).boolTrue).to.equal(true);
-		expect((new ExtendedTemplate2()).boolFalse).to.equal(false);
-		expect((new ExtendedTemplate2()).num).to.equal(100);
-		expect((new ExtendedTemplate2()).str).to.equal('Base');
-		expect((new ExtendedTemplate2()).obj.type).to.equal('Base');
-		expect((new ExtendedTemplate2()).date.getTime()).to.equal(100);
+    it('should extend a base class and create BaseTemplate2', function() {
 
-		expect((new ExtendedTemplate3()).boolTrue).to.equal(false);
-		expect((new ExtendedTemplate3()).boolFalse).to.equal(true);
-		expect((new ExtendedTemplate3()).num).to.equal(200);
-		expect((new ExtendedTemplate3()).str).to.equal('Extended');
-		expect((new ExtendedTemplate3()).obj.type).to.equal('Extended');
-		expect((new ExtendedTemplate3()).date.getTime()).to.equal(200);
-		console.log(JSON.stringify(BaseTemplate1.props.enum));
-		expect(BaseTemplate1.props.enum.values[0]).to.equal('b1');
-		expect((new BaseTemplate1()).__prop__('enum').values[0]).to.equal('b1');
-		expect((new BaseTemplate1()).__prop__('enum').descriptions['b1']).to.equal('BaseTemplate1');
-		expect((new ExtendedTemplate4()).__descriptions__('enum')['b3']).to.equal('Extended');
-		
-		
-	});
+        expect(ObjectTemplate.__templateUsage__['BaseTemplate1']).to.equal(undefined);
+
+        var extendedTemplate1 = new ExtendedTemplate1();
+
+        expect(ObjectTemplate.__templateUsage__['BaseTemplate1']).to.equal(true);
+        expect(ObjectTemplate.__templateUsage__['ExtendedTemplate1']).to.equal(true);
+
+        expect(extendedTemplate1.boolTrue).to.equal(false);
+        expect(extendedTemplate1.boolFalse).to.equal(true);
+        expect(extendedTemplate1.num).to.equal(200);
+        expect(extendedTemplate1.str).to.equal('Extended');
+        expect(extendedTemplate1.obj.type).to.equal('Extended');
+        expect(extendedTemplate1.date.getTime()).to.equal(200);
+
+    });
+
+    it('should extend a base class and be able to overwrite properties in it\'s init function', function() {
+        var extendedTemplate2 = new ExtendedTemplate2();
+
+        expect(extendedTemplate2.boolTrue).to.equal(true);
+        expect(extendedTemplate2.boolFalse).to.equal(false);
+        expect(extendedTemplate2.num).to.equal(100);
+        expect(extendedTemplate2.str).to.equal('Base');
+        expect(extendedTemplate2.obj.type).to.equal('Base');
+        expect(extendedTemplate2.date.getTime()).to.equal(100);
+    });
+
+    it('should extend a base class and use a previously used name and overwrite those properties in the dictionary', function() {
+        var extendedTemplate3 = new ExtendedTemplate3();
+
+        expect(extendedTemplate3.boolTrue).to.equal(false);
+        expect(extendedTemplate3.boolFalse).to.equal(true);
+        expect(extendedTemplate3.num).to.equal(200);
+        expect(extendedTemplate3.str).to.equal('Extended');
+        expect(extendedTemplate3.obj.type).to.equal('Extended');
+        expect(extendedTemplate3.date.getTime()).to.equal(200);
+
+        var baseTemplate1 = new BaseTemplate1();
+        expect(BaseTemplate1.props.enum.values[0]).to.equal('b1');
+        expect(baseTemplate1.__prop__('enum').values[0]).to.equal('b1');
+        expect(baseTemplate1.__prop__('enum').descriptions['b1']).to.equal('BaseTemplate1');
+    });
+
+    it('should extend an extended class', function() {
+        var extendedTemplate4 = new ExtendedTemplate4();
+        expect(extendedTemplate4.__descriptions__('enum')['b3']).to.equal('Extended');
+    });
+
 });


### PR DESCRIPTION
@CSMastermind @selsamman check this change out. I fixed up some of the unit tests so it describes a bit more of what is being tested and also added the feature so that extended templates will have `toClient` and `toServer` features. 

Right now the logic is as follow:

If a template extends another template the extended template will take the `createProps` which looks like this

```javascript
{
    name: 'name of extended template',
    toClient: true/false/['app1','app2'],
    toServer: true/false
}
```
but if only a name is defined then the `createProps` will be the settings from the parent template.
