### PR TITLE
Removed unused property __templateProps__

### DIFF
--- a/index.js
+++ b/index.js
@@ -1627,7 +1627,6 @@
         }
 
         // Called first time with parameter
-        var props = target;
         return decorator;
 
         // Decorator Workerbee
@@ -1639,9 +1638,8 @@
             target.prototype.amorphicGetClassName = function () {return target.__name__};
             target.isObjectTemplate = true;
             target.__injections__ = [];
-            target.__templateProps__ = props;
             target.__objectTemplate__ = objectTemplate;
-            var createProps = objectTemplate.getTemplateProperties(props || {});
+            var createProps = objectTemplate.getTemplateProperties(target || {});
             target.__toClient__ = createProps.__toClient__;
             target.__toServer__ = createProps.__toServer__;
             target.__shadowChildren__ = [];


### PR DESCRIPTION
Title says it all. This property isn't used anywhere from what I can tell. We should remove it since we already have references of the Class itself in `__template__` and `amorphicClass` on the prototype.